### PR TITLE
Fix inline comment highlight leaking to subsequent lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Tape files serve as both **visual documentation** (the generated GIFs are embedd
 
 Issue や PR を作成する際は、まず日本語でタイトル・本文をユーザーに提示して確認を取る。承認後、英語に翻訳して `gh` コマンドで作成する。
 
+Always assign appropriate labels when creating issues (e.g., `enhancement`, `bug`, `documentation`).
+
 ### Commit Messages
 
 Use gitmoji prefix: `✨` new feature, `🐛` bug fix, `🩹` minor fix, `♻️` refactor, `🔧` config, `📝` docs, etc.

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -294,17 +294,22 @@ fn highlight_line_colors(
     syntax_set: &SyntaxSet,
     highlighter: &Highlighter,
 ) -> Vec<Color> {
-    let ops = match parse_state.parse_line(line, syntax_set) {
+    // Append '\n' so that single-line comment scopes (matching `$`) close properly.
+    let line_with_nl = format!("{}\n", line);
+    let ops = match parse_state.parse_line(&line_with_nl, syntax_set) {
         Ok(ops) => ops,
         Err(_) => return Vec::new(),
     };
     let mut colors = Vec::new();
-    for (style, text) in HighlightIterator::new(highlight_state, &ops, line, highlighter) {
+    for (style, text) in HighlightIterator::new(highlight_state, &ops, &line_with_nl, highlighter)
+    {
         let color = syntect_to_ratatui_color(style.foreground);
         for _ in text.chars() {
             colors.push(color);
         }
     }
+    // Remove the trailing color entry produced by the appended '\n'.
+    colors.pop();
     colors
 }
 


### PR DESCRIPTION
## Summary
- Fix diff view where all lines after an inline comment (`//`, `#`) were incorrectly highlighted as comments
- Append `\n` to lines passed to syntect's `parse_line()` so single-line comment scopes close properly
- Add issue label rule to CLAUDE.md

## Test plan
- [x] `cargo clippy` — no new warnings
- [x] `cargo test` — all tests pass
- [x] Visually verified in vig that comment highlighting no longer leaks to subsequent lines

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)