### PR TITLE
Add `o` key to open GitHub Issues/PRs in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Browse GitHub Issues and Pull Requests directly within vig. Requires [GitHub CLI
 | `h` / `l` | Switch between Issue List and PR List |
 | `j` / `k` | Navigate list |
 | `i` / `Enter` | Open detail view |
+| `o` | Open in browser |
 | `Esc` | Back to list |
 | `Ctrl+d` / `Ctrl+u` | Half page scroll (detail view) |
 | `g` / `G` | Top / Bottom |

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -142,6 +142,7 @@ GitHub の Issue と Pull Request を vig 内で閲覧可能。[GitHub CLI (`gh`
 | `h` / `l` | Issue 一覧 ↔ PR 一覧 |
 | `j` / `k` | リスト内ナビゲーション |
 | `i` / `Enter` | 詳細ビューを開く |
+| `o` | ブラウザで開く |
 | `Esc` | 一覧に戻る |
 | `Ctrl+d` / `Ctrl+u` | 半ページスクロール（詳細ビュー） |
 | `g` / `G` | 先頭 / 末尾 |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1095,6 +1095,20 @@ impl App {
                     self.github.load_selected_issue_detail();
                 }
             }
+            KeyCode::Char('o') => {
+                if let Some(issue) = self.github.issues.get(self.github.issue_selected_idx) {
+                    let number = issue.number;
+                    match crate::github::client::open_issue_in_browser(number) {
+                        Ok(()) => {
+                            self.status_message =
+                                Some(format!("Opening issue #{number} in browser..."));
+                        }
+                        Err(e) => {
+                            self.status_message = Some(format!("Failed to open browser: {e}"));
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -1136,6 +1150,20 @@ impl App {
                     self.github.load_selected_pr_detail();
                 }
             }
+            KeyCode::Char('o') => {
+                if let Some(pr) = self.github.prs.get(self.github.pr_selected_idx) {
+                    let number = pr.number;
+                    match crate::github::client::open_pr_in_browser(number) {
+                        Ok(()) => {
+                            self.status_message =
+                                Some(format!("Opening PR #{number} in browser..."));
+                        }
+                        Err(e) => {
+                            self.status_message = Some(format!("Failed to open browser: {e}"));
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -1162,6 +1190,28 @@ impl App {
             KeyCode::Char('G') => {
                 // Scroll to a large value — rendering will cap it
                 self.github.detail_scroll = u16::MAX / 2;
+            }
+            KeyCode::Char('o') => {
+                let result = match &self.github.detail {
+                    crate::github::state::GhDetailContent::Issue(issue) => {
+                        let n = issue.number;
+                        crate::github::client::open_issue_in_browser(n)
+                            .map(|()| format!("Opening issue #{n} in browser..."))
+                    }
+                    crate::github::state::GhDetailContent::Pr(pr) => {
+                        let n = pr.number;
+                        crate::github::client::open_pr_in_browser(n)
+                            .map(|()| format!("Opening PR #{n} in browser..."))
+                    }
+                    _ => Err(String::new()),
+                };
+                match result {
+                    Ok(msg) => self.status_message = Some(msg),
+                    Err(e) if !e.is_empty() => {
+                        self.status_message = Some(format!("Failed to open browser: {e}"));
+                    }
+                    _ => {}
+                }
             }
             KeyCode::Esc => {
                 self.github.focused_pane = self.github.previous_pane;

--- a/src/github/client.rs
+++ b/src/github/client.rs
@@ -70,6 +70,28 @@ pub fn get_issue(number: u64) -> Result<GhIssueDetail, String> {
     serde_json::from_slice(&output.stdout).map_err(|e| format!("JSON parse error: {e}"))
 }
 
+pub fn open_issue_in_browser(number: u64) -> Result<(), String> {
+    Command::new("gh")
+        .args(["issue", "view", &number.to_string(), "--web"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("Failed to open issue in browser: {e}"))?;
+    Ok(())
+}
+
+pub fn open_pr_in_browser(number: u64) -> Result<(), String> {
+    Command::new("gh")
+        .args(["pr", "view", &number.to_string(), "--web"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("Failed to open PR in browser: {e}"))?;
+    Ok(())
+}
+
 pub fn get_pr(number: u64) -> Result<GhPrDetail, String> {
     let output = Command::new("gh")
         .args([

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -230,6 +230,7 @@ pub fn render_help_overlay(f: &mut Frame, area: Rect, view_mode: ViewMode) {
             ("h / l", "Issues ↔ PRs"),
             ("j / k", "Navigate list"),
             ("i / Enter", "Open detail"),
+            ("o", "Open in browser"),
             ("Esc", "Back to list"),
             ("Ctrl+d", "Half page down (detail)"),
             ("Ctrl+u", "Half page up (detail)"),


### PR DESCRIPTION
## Summary
- Press `o` in GitHub View (Issue list, PR list, or detail view) to open the selected item in the browser via `gh issue view --web` / `gh pr view --web`
- Uses non-blocking `spawn()` with null stdio to avoid interfering with the TUI
- Updated help overlay and README keybinding tables (EN/JA)

## Test plan
- [x] `cargo clippy` — no new warnings
- [x] `cargo run` → `2` (GitHub View) → select an issue → `o` → browser opens
- [x] Select a PR → `o` → browser opens
- [x] Open detail view (`i`) → `o` → browser opens from detail view
- [ ] Status bar shows feedback message after pressing `o`

🤖 Generated with [Claude Code](https://claude.com/claude-code)