### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,34 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
+  create-tag:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        run: gh release create ${{ steps.version.outputs.tag }} --target main --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
+    if: github.event_name == 'push'
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- Add `create-tag` job to release workflow: automatically creates a GitHub release with generated notes when a `release/*` branch is merged to main
- Merging this PR will trigger the v0.1.0 release pipeline (build → sign → publish → homebrew)

🤖 Generated with [Claude Code](https://claude.com/claude-code)