### PR TITLE
Use GitHub App token for auto-release on release branch merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,15 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: td72
+          repositories: vig
+
       - uses: actions/checkout@v6
 
       - name: Extract version from branch name
@@ -28,7 +37,7 @@ jobs:
       - name: Create release
         run: gh release create ${{ steps.version.outputs.tag }} --target main --generate-notes
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   build:
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Add `create-tag` job to release workflow that automatically creates a GitHub release with generated notes when a `release/*` branch is merged to main
- Use GitHub App token instead of `GITHUB_TOKEN` so the created tag triggers the build/sign/publish/homebrew pipeline
- After this is merged, releasing is as simple as merging a `release/v*` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)