### PR TITLE
Use release event for crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+  release:
+    types: [created]
   workflow_run:
     workflows: [Build]
     types: [completed]
@@ -42,7 +44,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
   publish:
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     environment: release
     permissions:
@@ -51,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.release.tag_name }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 


### PR DESCRIPTION
## Summary
- crates.io Trusted Publishing does not support `workflow_run` event trigger
- Switch publish job to use `release` event (fires when create-tag creates the GitHub Release)
- homebrew remains on `workflow_run` (needs build artifacts)

## Test plan
- [ ] Merge and retry v0.1.0 release
- [ ] Verify publish job triggers on release creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)