### PR TITLE
Fix crates.io publish token propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,13 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Authenticate with crates.io
+        id: crates-auth
         uses: rust-lang/crates-io-auth-action@v1
 
       - name: Publish to crates.io
         run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-auth.outputs.token }}
 
   homebrew:
     if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')


### PR DESCRIPTION
## Summary
- Pass `crates-io-auth-action` token output explicitly via `CARGO_REGISTRY_TOKEN` env var
- The action outputs the token as a step output, not as an auto-exported env var

## Test plan
- [ ] Merge and retry v0.1.0 release
- [ ] Verify `cargo publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)