### PR TITLE
Release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,7 +2659,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vig"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vig"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Git TUI side-by-side diff viewer"
 authors = ["td72"]


### PR DESCRIPTION
## Summary
- Bump version to v0.1.1 to sync crates.io package with GitHub Release binaries
- crates.io v0.1.0 was published manually before CI/CD fixes (thin LTO, workflow split, token propagation), so a new release aligns everything

## Test plan
- [ ] CI passes (clippy, test)
- [ ] After merge, automated flow: create-tag → Build → publish + homebrew

🤖 Generated with [Claude Code](https://claude.com/claude-code)