### PR TITLE
Add disk cache for GitHub Issues/PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,6 +2339,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3233,6 +3271,7 @@ dependencies = [
  "arboard",
  "clap",
  "crossterm 0.28.1",
+ "dirs",
  "git2",
  "notify",
  "notify-debouncer-mini",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ notify-debouncer-mini = "0.5"
 ratatui = "0.30"
 pulldown-cmark = { version = "0.13", default-features = false, features = ["simd"] }
 arboard = "3"
+dirs = "6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }

--- a/src/github/disk_cache.rs
+++ b/src/github/disk_cache.rs
@@ -1,0 +1,221 @@
+use crate::github::types::*;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+const CACHE_VERSION: &str = "v1";
+
+/// Extract "owner/repo" from the git remote URL (local operation, no network).
+fn repo_nwo() -> Option<&'static str> {
+    static NWO: OnceLock<Option<String>> = OnceLock::new();
+    NWO.get_or_init(|| {
+        let repo = git2::Repository::open_from_env().ok()?;
+        let remote = repo.find_remote("origin").ok()?;
+        let url = remote.url()?;
+        parse_github_nwo(url)
+    })
+    .as_deref()
+}
+
+/// Parse "owner/repo" from a GitHub remote URL.
+/// Supports HTTPS (`https://github.com/owner/repo.git`) and SSH (`git@github.com:owner/repo.git`).
+fn parse_github_nwo(url: &str) -> Option<String> {
+    let path = if let Some(rest) = url.strip_prefix("git@github.com:") {
+        rest
+    } else {
+        url.split("github.com/").nth(1)?
+    };
+    let path = path.strip_suffix(".git").unwrap_or(path);
+    // Validate it looks like "owner/repo"
+    let parts: Vec<&str> = path.splitn(3, '/').collect();
+    if parts.len() == 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+        Some(format!("{}/{}", parts[0], parts[1]))
+    } else {
+        None
+    }
+}
+
+/// Build the cache directory path: `<cache_dir>/vig/<version>/<owner>/<repo>/`
+fn cache_dir() -> Option<PathBuf> {
+    let base = dirs::cache_dir()?;
+    let nwo = repo_nwo()?;
+    Some(base.join("vig").join(CACHE_VERSION).join(nwo))
+}
+
+fn load_json<T: serde::de::DeserializeOwned>(path: &PathBuf) -> Option<T> {
+    let data = fs::read(path).ok()?;
+    serde_json::from_slice(&data).ok()
+}
+
+fn save_json<T: serde::Serialize>(path: &PathBuf, value: &T) {
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    if fs::create_dir_all(parent).is_err() {
+        return;
+    }
+    let Ok(data) = serde_json::to_vec(value) else {
+        return;
+    };
+    // Write to a temp file then rename for atomicity
+    let tmp = path.with_extension("tmp");
+    let Ok(mut f) = fs::File::create(&tmp) else {
+        return;
+    };
+    if f.write_all(&data).is_err() {
+        let _ = fs::remove_file(&tmp);
+        return;
+    }
+    let _ = fs::rename(&tmp, path);
+}
+
+pub fn load_issue_list() -> Option<Vec<GhIssueListItem>> {
+    load_json(&cache_dir()?.join("issues.json"))
+}
+
+pub fn save_issue_list(issues: &[GhIssueListItem]) {
+    if let Some(dir) = cache_dir() {
+        save_json(&dir.join("issues.json"), &issues);
+    }
+}
+
+pub fn load_pr_list() -> Option<Vec<GhPrListItem>> {
+    load_json(&cache_dir()?.join("prs.json"))
+}
+
+pub fn save_pr_list(prs: &[GhPrListItem]) {
+    if let Some(dir) = cache_dir() {
+        save_json(&dir.join("prs.json"), &prs);
+    }
+}
+
+pub fn load_issue_detail(number: u64) -> Option<GhIssueDetail> {
+    load_json(&cache_dir()?.join("issue").join(format!("{number}.json")))
+}
+
+pub fn save_issue_detail(detail: &GhIssueDetail) {
+    if let Some(dir) = cache_dir() {
+        save_json(&dir.join("issue").join(format!("{}.json", detail.number)), detail);
+    }
+}
+
+pub fn load_pr_detail(number: u64) -> Option<GhPrDetail> {
+    load_json(&cache_dir()?.join("pr").join(format!("{number}.json")))
+}
+
+pub fn save_pr_detail(detail: &GhPrDetail) {
+    if let Some(dir) = cache_dir() {
+        save_json(&dir.join("pr").join(format!("{}.json", detail.number)), detail);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_parse_github_nwo_ssh_with_git_suffix() {
+        assert_eq!(
+            parse_github_nwo("git@github.com:td72/vig.git"),
+            Some("td72/vig".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_github_nwo_ssh_without_git_suffix() {
+        assert_eq!(
+            parse_github_nwo("git@github.com:td72/vig"),
+            Some("td72/vig".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_github_nwo_https_with_git_suffix() {
+        assert_eq!(
+            parse_github_nwo("https://github.com/td72/vig.git"),
+            Some("td72/vig".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_github_nwo_https_without_git_suffix() {
+        assert_eq!(
+            parse_github_nwo("https://github.com/td72/vig"),
+            Some("td72/vig".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_github_nwo_invalid_url() {
+        assert_eq!(parse_github_nwo("https://gitlab.com/foo/bar"), None);
+        assert_eq!(parse_github_nwo("not-a-url"), None);
+    }
+
+    #[test]
+    fn test_parse_github_nwo_no_repo() {
+        assert_eq!(parse_github_nwo("git@github.com:td72"), None);
+        assert_eq!(parse_github_nwo("https://github.com/td72"), None);
+    }
+
+    #[test]
+    fn test_repo_nwo_resolves() {
+        // Running within the vig repo, so this should succeed
+        let nwo = repo_nwo();
+        assert!(nwo.is_some(), "repo_nwo() returned None");
+        assert_eq!(nwo.unwrap(), "td72/vig");
+    }
+
+    #[test]
+    fn test_cache_dir_resolves() {
+        let dir = cache_dir();
+        assert!(dir.is_some(), "cache_dir() returned None");
+        let dir = dir.unwrap();
+        assert!(
+            dir.ends_with("vig/v1/td72/vig"),
+            "unexpected cache dir: {}",
+            dir.display()
+        );
+    }
+
+    #[test]
+    fn test_save_and_load_json_roundtrip() {
+        let tmp = std::env::temp_dir().join("vig_test_cache");
+        let _ = fs::remove_dir_all(&tmp);
+
+        let issues = vec![GhIssueListItem {
+            number: 99999,
+            title: "Test issue".to_string(),
+            state: "OPEN".to_string(),
+            author: None,
+            labels: vec![],
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+        }];
+
+        let path = tmp.join("issues.json");
+        save_json(&path, &issues);
+        let loaded: Option<Vec<GhIssueListItem>> = load_json(&path);
+        assert!(loaded.is_some(), "load_json returned None");
+        assert_eq!(loaded.unwrap()[0].number, 99999);
+
+        let detail = GhIssueDetail {
+            number: 88888,
+            title: "Test detail".to_string(),
+            state: "OPEN".to_string(),
+            author: None,
+            body: "body".to_string(),
+            comments: vec![],
+            labels: vec![],
+            created_at: "2025-01-01T00:00:00Z".to_string(),
+        };
+
+        let path = tmp.join("issue/88888.json");
+        save_json(&path, &detail);
+        let loaded: Option<GhIssueDetail> = load_json(&path);
+        assert!(loaded.is_some(), "load_json returned None");
+        assert_eq!(loaded.unwrap().number, 88888);
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+}

--- a/src/github/disk_cache.rs
+++ b/src/github/disk_cache.rs
@@ -24,7 +24,7 @@ fn parse_github_nwo(url: &str) -> Option<String> {
     let path = if let Some(rest) = url.strip_prefix("git@github.com:") {
         rest
     } else {
-        url.split("github.com/").nth(1)?
+        url.split("://github.com/").nth(1)?
     };
     let path = path.strip_suffix(".git").unwrap_or(path);
     // Validate it looks like "owner/repo"
@@ -150,6 +150,7 @@ mod tests {
     #[test]
     fn test_parse_github_nwo_invalid_url() {
         assert_eq!(parse_github_nwo("https://gitlab.com/foo/bar"), None);
+        assert_eq!(parse_github_nwo("https://notgithub.com/foo/bar"), None);
         assert_eq!(parse_github_nwo("not-a-url"), None);
     }
 
@@ -161,10 +162,14 @@ mod tests {
 
     #[test]
     fn test_repo_nwo_resolves() {
-        // Running within the vig repo, so this should succeed
         let nwo = repo_nwo();
         assert!(nwo.is_some(), "repo_nwo() returned None");
-        assert_eq!(nwo.unwrap(), "td72/vig");
+        let nwo = nwo.unwrap();
+        // Verify "owner/repo" format without hardcoding specific values
+        let parts: Vec<&str> = nwo.split('/').collect();
+        assert_eq!(parts.len(), 2, "expected owner/repo format, got: {nwo}");
+        assert!(!parts[0].is_empty(), "owner is empty");
+        assert!(!parts[1].is_empty(), "repo is empty");
     }
 
     #[test]
@@ -172,8 +177,10 @@ mod tests {
         let dir = cache_dir();
         assert!(dir.is_some(), "cache_dir() returned None");
         let dir = dir.unwrap();
+        // Verify path contains versioned cache structure
+        let dir_str = dir.to_string_lossy();
         assert!(
-            dir.ends_with("vig/v1/td72/vig"),
+            dir_str.contains(&format!("vig/{CACHE_VERSION}/")),
             "unexpected cache dir: {}",
             dir.display()
         );

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -1,3 +1,4 @@
 pub mod client;
+pub mod disk_cache;
 pub mod state;
 pub mod types;

--- a/src/github/state.rs
+++ b/src/github/state.rs
@@ -1,4 +1,5 @@
 use crate::github::client;
+use crate::github::disk_cache;
 use crate::github::types::*;
 use std::collections::HashMap;
 use std::sync::mpsc;
@@ -153,9 +154,23 @@ impl GitHubState {
             return;
         }
         self.initialized = true;
+
         let (tx, rx) = mpsc::channel();
         self.bg_tx = Some(tx.clone());
         self.bg_rx = Some(rx);
+
+        // Load cached lists from disk (instant display, will be refreshed in background)
+        if let Some(issues) = disk_cache::load_issue_list() {
+            self.issues = issues;
+        }
+        if let Some(prs) = disk_cache::load_pr_list() {
+            self.prs = prs;
+        }
+
+        // Auto-load detail for the first item from disk cache
+        if !self.issues.is_empty() {
+            self.load_selected_issue_detail();
+        }
 
         self.issues_loading = true;
         self.prs_loading = true;
@@ -208,6 +223,7 @@ impl GitHubState {
                     self.issues_loading = false;
                     match result {
                         Ok(issues) => {
+                            disk_cache::save_issue_list(&issues);
                             self.issues = issues;
                             issue_list_arrived = true;
                         }
@@ -222,6 +238,7 @@ impl GitHubState {
                     self.prs_loading = false;
                     match result {
                         Ok(prs) => {
+                            disk_cache::save_pr_list(&prs);
                             self.prs = prs;
                             pr_list_arrived = true;
                         }
@@ -234,6 +251,7 @@ impl GitHubState {
                 }
                 GhBgMessage::IssueDetail(result) => match result {
                     Ok(detail) => {
+                        disk_cache::save_issue_detail(&detail);
                         self.issue_cache.insert(detail.number, detail.clone());
                         self.detail = GhDetailContent::Issue(Box::new(detail));
                     }
@@ -244,6 +262,7 @@ impl GitHubState {
                     match result {
                         Ok(detail) => {
                             self.watch_error = None;
+                            disk_cache::save_pr_detail(&detail);
                             self.pr_cache.insert(detail.number, detail.clone());
                             self.detail = GhDetailContent::Pr(Box::new(detail));
                         }
@@ -280,6 +299,13 @@ impl GitHubState {
             self.reset_detail_panes();
             return;
         }
+        // Disk cache fallback
+        if let Some(cached) = disk_cache::load_issue_detail(number) {
+            self.issue_cache.insert(number, cached.clone());
+            self.detail = GhDetailContent::Issue(Box::new(cached));
+            self.reset_detail_panes();
+            return;
+        }
         self.detail = GhDetailContent::Loading {
             kind: GhDetailKind::Issue,
             number,
@@ -298,6 +324,13 @@ impl GitHubState {
     pub fn load_pr_detail(&mut self, number: u64) {
         if let Some(cached) = self.pr_cache.get(&number) {
             self.detail = GhDetailContent::Pr(Box::new(cached.clone()));
+            self.reset_detail_panes();
+            return;
+        }
+        // Disk cache fallback
+        if let Some(cached) = disk_cache::load_pr_detail(number) {
+            self.pr_cache.insert(number, cached.clone());
+            self.detail = GhDetailContent::Pr(Box::new(cached));
             self.reset_detail_panes();
             return;
         }

--- a/src/github/types.rs
+++ b/src/github/types.rs
@@ -1,17 +1,17 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhAuthor {
     pub login: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhLabel {
     pub name: String,
     pub color: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhComment {
     pub author: Option<GhAuthor>,
     pub body: String,
@@ -20,7 +20,7 @@ pub struct GhComment {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhReview {
     pub author: Option<GhAuthor>,
     pub body: String,
@@ -28,7 +28,7 @@ pub struct GhReview {
     pub id: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhStatusCheck {
     pub name: String,
     pub status: String,
@@ -45,7 +45,7 @@ pub struct GhStatusCheck {
 
 // Issue list item — some fields populated by serde only
 #[allow(dead_code)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhIssueListItem {
     pub number: u64,
     pub title: String,
@@ -57,7 +57,7 @@ pub struct GhIssueListItem {
 }
 
 // Issue detail
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhIssueDetail {
     pub number: u64,
     pub title: String,
@@ -72,7 +72,7 @@ pub struct GhIssueDetail {
 
 // PR list item — some fields populated by serde only
 #[allow(dead_code)]
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhPrListItem {
     pub number: u64,
     pub title: String,
@@ -90,7 +90,7 @@ pub struct GhPrListItem {
 }
 
 // PR detail
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GhPrDetail {
     pub number: u64,
     pub title: String,

--- a/src/ui/github/issue_list.rs
+++ b/src/ui/github/issue_list.rs
@@ -17,7 +17,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 
-    if app.github.issues_loading {
+    if app.github.issues_loading && app.github.issues.is_empty() {
         let items = vec![ListItem::new(Line::from(Span::styled(
             "  Loading...",
             Style::default().fg(Color::DarkGray),

--- a/src/ui/github/pr_list.rs
+++ b/src/ui/github/pr_list.rs
@@ -17,7 +17,7 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color));
 
-    if app.github.prs_loading {
+    if app.github.prs_loading && app.github.prs.is_empty() {
         let items = vec![ListItem::new(Line::from(Span::styled(
             "  Loading...",
             Style::default().fg(Color::DarkGray),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -156,8 +156,12 @@ pub fn render_gh_status_bar(f: &mut Frame, app: &App, area: Rect) {
     let issue_count = app.github.issues.len();
     let pr_count = app.github.prs.len();
 
+    let loading = app.github.issues_loading || app.github.prs_loading;
+    let has_data = issue_count > 0 || pr_count > 0;
+
     let mut spans = Vec::new();
-    if app.github.issues_loading || app.github.prs_loading {
+    if loading && !has_data {
+        // Initial load (no cache) — show Loading...
         spans.push(Span::styled(
             " Loading...",
             Style::default().fg(Color::DarkGray),
@@ -176,6 +180,14 @@ pub fn render_gh_status_bar(f: &mut Frame, app: &App, area: Rect) {
             format!("{} PR{}", pr_count, if pr_count == 1 { "" } else { "s" }),
             Style::default().fg(Color::White),
         ));
+        if loading {
+            // Background refresh with cached data visible
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(
+                "↻ Updating...",
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
     }
 
     if let Some(time) = app.github.watch_last_update_time() {


### PR DESCRIPTION
## Summary
- Cache GitHub Issue/PR data to disk for instant display on subsequent launches (stale-while-revalidate)
- Background refresh fetches latest data while cached data is shown immediately
- Status bar shows "↻ Updating..." indicator during background refresh

## Test plan
- [x] `cargo clippy` passes
- [x] `cargo test disk_cache` — 9 tests pass (URL parsing, cache path resolution, save/load roundtrip)
- [x] First launch: no cache → Loading shown → cache files created after data fetch
- [x] Second launch: lists and detail displayed instantly from cache → background update
- [x] `r` key refresh → cache updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)