### PR TITLE
🔧 Drop x86_64-apple-darwin (Intel macOS) support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,6 @@ jobs:
             runner: ubuntu-24.04-arm
           - target: aarch64-apple-darwin
             runner: macos-latest
-          - target: x86_64-apple-darwin
-            runner: macos-15-intel
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,6 @@ jobs:
             runner: ubuntu-latest
           - target: aarch64-apple-darwin
             runner: macos-latest
-          - target: x86_64-apple-darwin
-            runner: macos-15-intel
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,6 @@ jobs:
           SHA_LINUX_X86=$(cut -d ' ' -f 1 vig-x86_64-unknown-linux-gnu.tar.gz.sha256)
           SHA_LINUX_ARM=$(cut -d ' ' -f 1 vig-aarch64-unknown-linux-gnu.tar.gz.sha256)
           SHA_MACOS_ARM=$(cut -d ' ' -f 1 vig-aarch64-apple-darwin.tar.gz.sha256)
-          SHA_MACOS_X86=$(cut -d ' ' -f 1 vig-x86_64-apple-darwin.tar.gz.sha256)
 
           cat > homebrew-tap/Formula/vig.rb <<FORMULA
           class Vig < Formula
@@ -116,10 +115,6 @@ jobs:
               on_arm do
                 url "https://github.com/td72/vig/releases/download/v#{version}/vig-aarch64-apple-darwin.tar.gz"
                 sha256 "${SHA_MACOS_ARM}"
-              end
-              on_intel do
-                url "https://github.com/td72/vig/releases/download/v#{version}/vig-x86_64-apple-darwin.tar.gz"
-                sha256 "${SHA_MACOS_X86}"
               end
             end
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ curl -sL https://github.com/td72/vig/releases/latest/download/vig-aarch64-unknow
 
 # macOS Apple Silicon
 curl -sL https://github.com/td72/vig/releases/latest/download/vig-aarch64-apple-darwin.tar.gz | tar xz -C ~/.local/bin vig
-
-# macOS Intel
-curl -sL https://github.com/td72/vig/releases/latest/download/vig-x86_64-apple-darwin.tar.gz | tar xz -C ~/.local/bin vig
 ```
 
 ### crates.io

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -41,9 +41,6 @@ curl -sL https://github.com/td72/vig/releases/latest/download/vig-aarch64-unknow
 
 # macOS Apple Silicon
 curl -sL https://github.com/td72/vig/releases/latest/download/vig-aarch64-apple-darwin.tar.gz | tar xz -C ~/.local/bin vig
-
-# macOS Intel
-curl -sL https://github.com/td72/vig/releases/latest/download/vig-x86_64-apple-darwin.tar.gz | tar xz -C ~/.local/bin vig
 ```
 
 ### crates.io


### PR DESCRIPTION
## 概要
Intel macOS（`x86_64-apple-darwin`）をサポート対象から外す。

## 理由
GitHub Actions の Intel macOS ランナー（`macos-15-intel`）はキュー待ちが長く、CI を不安定化させている（例: PR #60 では Intel build が 10分超かかり、他ジョブが揃ってもしばらく pending のままだった）。

## 継続サポート対象
- `aarch64-apple-darwin`（Apple Silicon）
- `x86_64-unknown-linux-gnu` / `aarch64-unknown-linux-gnu`（Linux）

## 変更内容
- `.github/workflows/ci.yml` — test/build matrix から `x86_64-apple-darwin` を削除
- `.github/workflows/build.yml` — リリースビルド matrix から削除
- `.github/workflows/release.yml` — Homebrew formula 生成の `SHA_MACOS_X86` と macOS `on_intel` ブロックを削除（Linux 側 `on_intel` は維持）
- `README.md` / `docs/README.ja.md` — 「macOS Intel」インストール手順を削除

UI 変更なしのため tape/GIF 更新は不要。

> [!NOTE]
> Copilot レビューを Web UI（PR → Reviewers → Copilot）から手動で追加してください。